### PR TITLE
- compatibility with newest unity (5.4.1) issues fixed

### DIFF
--- a/src/Assets/Shortcuter/Editor/Windows/ShortcutWindow.cs
+++ b/src/Assets/Shortcuter/Editor/Windows/ShortcutWindow.cs
@@ -94,7 +94,7 @@ namespace Intentor.Shortcuter.Windows {
 
 					if (GUILayout.Button(fileName)) {
 						if (shortcutType.typeName == "Scene") {
-							#if UNITY_5_3
+							#if UNITY_5_3_OR_NEWER
 							EditorSceneManager.OpenScene(path, OpenSceneMode.Single);
 							#else
 							EditorApplication.OpenScene(path);

--- a/src/ProjectSettings/ProjectVersion.txt
+++ b/src/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.3.5p7
+m_EditorVersion: 5.4.1p2
 m_StandardAssetsVersion: 0


### PR DESCRIPTION
Removed warning due to wrong define and using deprecated method - compatible with newest (5.4.1p2) unity now.
